### PR TITLE
Page Navigator has disappeared

### DIFF
--- a/extension/css/salr.css
+++ b/extension/css/salr.css
@@ -19,7 +19,7 @@ nav#page-nav {
     background: #006699;
     float: right;
     position: fixed;
-    bottom: -50px;
+    bottom: 0px;
     right: 10px;
     padding-bottom: 2px;
     padding-left: 4px;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -133,6 +133,7 @@
     "images/sticky_on.gif",
     "images/unvisit.png",
     "imgur-upload.html",
-    "images/emoticons/*"
+    "images/emoticons/*",
+    "js/jquery/jquery.min.map"
   ]
 }


### PR DESCRIPTION
The page navigator has disappeared - the addition of translateZ(0) means that the bottom co-ord should be 0px not -50px.

Also my chrome console was warning about jquery.min.map not being in the web accessible resources component of the manifest so I've added that
