### PR TITLE
added ability for SALR to set image tooltip based on image filename

### DIFF
--- a/extension/js/message-handler.js
+++ b/extension/js/message-handler.js
@@ -239,6 +239,10 @@ defaultSettings['fixImgurLinks']                = 'true';
 //defaultSettings['fixTimg']                      = 'false';
 //defaultSettings['forceTimg']                    = 'false';
 defaultSettings['retinaImages']                 = 'false';
+defaultSettings['setImageTooltip']              = 'false';
+defaultSettings['setImageTooltipBlankOnly']     = 'true';
+defaultSettings['setImageTooltipHideExtension'] = 'true';
+defaultSettings['setImageTooltipSkipEmoticons'] = 'true';
     
 // Other Options
 defaultSettings['qneProtection']                = 'false';      

--- a/extension/js/salr.js
+++ b/extension/js/salr.js
@@ -198,6 +198,11 @@ SALR.prototype.pageInit = function() {
             if (this.settings.retinaImages == 'true') {
                 this.swapRetinaEmotes();
             }
+
+            if (this.settings.setImageTooltip == 'true') {
+                this.setImageTooltips();
+            }
+
             if (this.settings.hidePostButtonInThread == 'true') {
                 this.hidePostButtonInThread();
             }
@@ -2297,6 +2302,46 @@ function retinaFilename(img) {
 
     var f = filenameSegments.join('.')
     return f;
+}
+
+SALR.prototype.setImageTooltips = function() {
+    var salr = this;
+    
+    jQuery('td.postbody img').filter(function(index) {
+        if(salr.settings.setImageTooltipBlankOnly === 'true') {
+            if(jQuery(this).attr('title') !== undefined && jQuery(this).attr('title').length > 0) { return false; }
+        } 
+
+        if(salr.settings.setImageTooltipSkipEmoticons === 'true') {
+            var emoticon_paths = [
+                '//fi.somethingawful.com/customtitles',
+                '//fi.somethingawful.com/images/smilies',
+                '//fi.somethingawful.com/safs/smilies',
+                '//fi.somethingawful.com/smilies',
+                '//i.somethingawful.com/forumsystem/emoticons',
+                '//i.somethingawful.com/images',
+                '//i.somethingawful.com/mjolnir/images',
+                '//i.somethingawful.com/u/garbageday'
+            ];
+
+            var img_path = jQuery(this).attr('src');
+            img_path = img_path.substr(img_path.indexOf('//'));
+            
+            for(var idx = 0; idx < emoticon_paths.length; ++idx) {
+                var path = emoticon_paths[idx];
+                if(path.toLowerCase() == img_path.substr(0,path.length).toLowerCase()) { return false; }
+            }
+        }
+
+        return true;
+    }).each(function(index,element) {
+        var filename = jQuery(this).attr('src');
+        filename = filename.substr(filename.lastIndexOf('/')+1);
+        if(salr.settings.setImageTooltipHideExtension) {
+            filename = filename.substring(0, filename.lastIndexOf('.'));
+        }
+        jQuery(this).attr('title',filename);
+    });
 }
 
 SALR.prototype.hidePostButtonInThread = function() {

--- a/extension/settings.html
+++ b/extension/settings.html
@@ -810,6 +810,24 @@
                 <label><input id='retinaImages' class='user-preference' type='checkbox' /> Enable retina images</label>
             </div>
         </div>
+
+        <span class='settings-group-title'>Image Tooltip</span>
+        <div class='settings-group'>
+            <div class='display-preference'>
+                <label><input id='setImageTooltip' class='user-preference' type='checkbox' /> Set image tooltip to file name</label>
+            </div>
+            <div class='sub-options'>
+                <div class='display-preference'>
+                    <label><input id='setImageTooltipBlankOnly' class='user-preference' type='checkbox' /> Only when not already set</label>
+                </div>
+                <div class='display-preference'>
+                    <label><input id='setImageTooltipHideExtension' class='user-preference' type='checkbox' /> Hide image file extension</label>
+                </div>
+                <div class='display-preference'>
+                    <label><input id='setImageTooltipSkipEmoticons' class='user-preference' type='checkbox' /> Don't set for emoticons</label>
+                </div>
+            </div>
+        </div>
         <div style="clear: both;"></div>
         <br />
     </section>


### PR DESCRIPTION
I have added the ability for SALR to set an image's tooltip based on the file name. In addition, I gave some basic options for user control, including:
- the option to leave emoticon tooltips alone (Default on)
- the option to leave tooltips alone when already set (Default on)
- the option to strip the file extension off the tooltip (Default on)

The new master setting will default to off, so people won't be wondering why their images are suddenly displaying weird text when they mouse over them.

Because files for emoticons are a bit scattered, and I've seen non-emoticon images hosted on the somethingawful domain, the paths to their general locations are hard coded, and will need to be updated should the forums software ever change where emoticons are stored.
