### PR TITLE
Fix quicksearch endpoint

### DIFF
--- a/extension/js/salr.js
+++ b/extension/js/salr.js
@@ -1159,7 +1159,7 @@ SALR.prototype.addSearchThreadForm = function() {
     var threadid = findThreadID();
     searchHTML = '<span id="salrsearch">'+
            '<form id="salrSearchForm" '+
-            'action="http://forums.somethingawful.com/query" '+
+            'action="http://forums.somethingawful.com/query.php" '+
             'method="post" _lpchecked="1">'+
            //'<input type="hidden" name="forumids" value="'+forumid+'">'+
            /*


### PR DESCRIPTION
Missing a '.php'- current implementation raises a 404.