### PR TITLE
Fix Quicksearch on Enter Submit

### DIFF
--- a/extension/js/salr.js
+++ b/extension/js/salr.js
@@ -1175,8 +1175,8 @@ SALR.prototype.addSearchThreadForm = function() {
            '<input type="hidden" name="username_filter" value="type a username">'+
             */
            '<input id="salrSearch" name="q" size="25" style="">'+
-           //'<input type="submit" value="Search thread">'+
-           '<button type="submit" name="action" value="query">Search</button>'
+           '<input name="action" value="query" type="hidden">'+
+           '<button type="submit">Search</button>'+
            '</form>'+
            '</span>';
 


### PR DESCRIPTION
Existing code submitted the form without the 'action' => 'query' form
data. This would cause a search to fail. I've moved that data into a
hidden input so it will always be submitted regardless of submission
method (click or enter).