### PR TITLE
Fixed gesture overlay offset in chrome beta

### DIFF
--- a/extension/css/mouse-gestures.css
+++ b/extension/css/mouse-gestures.css
@@ -5,6 +5,10 @@ div#gesture-overlay {
     z-index: 99;
 }
 
+div#gesture-overlay img {
+    display: block;
+}
+
 div#gesture-top, div#gesture-bottom {
     position: relative;
     left: 50%;
@@ -12,14 +16,13 @@ div#gesture-top, div#gesture-bottom {
 }
 
 div#gesture-top {
-    top: 3px;
     margin-left: -39px;
     /*right: 10px;*/
 }
 
 div#gesture-bottom {
     position: absolute;
-    top: 157px;
+    top: 154px;
     margin-left: -39px;
 }
 


### PR DESCRIPTION
Made the images in the overlay display in block mode to remove inline padding.
Also removed vertical offsets from the top and bottom gesture divs so that it all lines up again.