### PR TITLE
Quick Fix for Emote Parsing

### DIFF
--- a/extension/js/quick-reply.js
+++ b/extension/js/quick-reply.js
@@ -574,10 +574,10 @@ QuickReplyBox.prototype.toggleTopbar = function() {
     }
 };
 
-QuickReplyBox.prototype.notify = function(emotes) {
+QuickReplyBox.prototype.notify = function(emotes, sortedEmotes) {
     var that = this;
     this.emotes = emotes;
-    this.sortedEmotes = this.emote_parser.getSortedEmotes();
+    this.sortedEmotes = sortedEmotes;
 
     jQuery('#post-message').keyup(function() {
         that.updatePreview();


### PR DESCRIPTION
* Caches emotes and emotesArray in localStorage
* Cache is used until it's a day old

Caveat: The images aren't loaded until the smilies button on the quick reply modal is clicked,
which now has a noticeable delay. This does alleviate everyday browsing significantly, however.