### PR TITLE
Quick Reply Preview Fixes

### DIFF
--- a/extension/js/quick-reply.js
+++ b/extension/js/quick-reply.js
@@ -569,6 +569,7 @@ QuickReplyBox.prototype.toggleTopbar = function() {
         top_bar.animate( { bottom: '-=' + (320-(390-this.quickReplyState.height)) + 'px' } );
         this.quickReplyState.topbar_visible = false;
     } else {
+        this.updatePreview();
         top_bar.animate( { bottom: '+=' + (320-(390-this.quickReplyState.height)) + 'px' } );
         this.quickReplyState.topbar_visible = true;
     }
@@ -579,8 +580,10 @@ QuickReplyBox.prototype.notify = function(emotes, sortedEmotes) {
     this.emotes = emotes;
     this.sortedEmotes = sortedEmotes;
 
-    jQuery('#post-message').keyup(function() {
+    jQuery(document).on('keyup', '#post-message', function() {
+      if (that.quickReplyState.topbar_visible) {
         that.updatePreview();
+      }
     });
 
     this.setEmoteSidebar();


### PR DESCRIPTION
* Scoping keyup event to document and filtering by message input ID
  * Short-circuits when preview panel is hidden to avoid unnecessary work
* Update live preview on any panel extension
  * Fixes case where a reply is crafted and then is desired to be previewed-
    it would not actually update until a change was made in the textbox.